### PR TITLE
remove unused fmt import, bundle all imports in one statement

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,10 +1,11 @@
 package common
 
-import "os"
-import "crypto/tls"
-import "crypto/x509"
-import "io/ioutil"
-import "fmt"
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+)
 
 func MustLoadCertificates() (tls.Certificate, *x509.CertPool) {
 	l := len(os.Args)


### PR DESCRIPTION
Currently go get produces the following error:

$ GOPATH=/tmp/foo go get -v github.com/hydrogen18/test-tls
github.com/hydrogen18/test-tls (download)
github.com/hydrogen18/test-tls
# github.com/hydrogen18/test-tls

/tmp/foo/src/github.com/hydrogen18/test-tls/common.go:7: imported and not used: "fmt"
